### PR TITLE
Fix unapproved verbs warning

### DIFF
--- a/PSDiscoveryProtocol/PSDiscoveryProtocol.psd1
+++ b/PSDiscoveryProtocol/PSDiscoveryProtocol.psd1
@@ -70,10 +70,10 @@ DotNetFrameworkVersion = '4.6'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
-    'Capture-CDPPacket',
-    'Capture-LLDPPacket',
-    'Parse-CDPPacket',
-    'Parse-LLDPPacket'
+    'Get-CDPPacket',
+    'Get-LLDPPacket',
+    'ConvertFrom-CDPPacket',
+    'ConvertFrom-LLDPPacket'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -83,7 +83,12 @@ FunctionsToExport = @(
 # VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-# AliasesToExport = @()
+AliasesToExport = @(
+    'Capture-CDPPacket',
+    'Capture-LLDPPacket',
+    'Parse-CDPPacket',
+    'Parse-LLDPPacket'
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
+++ b/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
@@ -1,5 +1,5 @@
 ﻿#region function Capture-CDPPacket
-function Capture-CDPPacket {
+function Get-CDPPacket {
 
 <#
 
@@ -64,6 +64,7 @@ function Capture-CDPPacket {
 #>
 
     [CmdletBinding()]
+    [Alias('Capture-CDPPacket')]
     param(
         [Parameter(Position=0,
             ValueFromPipeline=$true,
@@ -156,7 +157,7 @@ function Capture-CDPPacket {
 #endregion
 
 #region function Parse-CDPPacket
-function Parse-CDPPacket {
+function ConvertFrom-CDPPacket {
 
 <#
 
@@ -212,6 +213,7 @@ function Parse-CDPPacket {
 #>
 
     [CmdletBinding()]
+    [Alias('Parse-CDPPacket')]
     param(
         [Parameter(Position=0,
             Mandatory=$true,
@@ -259,7 +261,7 @@ function Parse-CDPPacket {
 #endregion
 
 #region function Capture-LLDPPacket
-function Capture-LLDPPacket {
+function Get-LLDPPacket {
 
 <#
 
@@ -328,6 +330,7 @@ function Capture-LLDPPacket {
 #>
 
     [CmdletBinding()]
+    [Alias('Capture-LLDPPacket')]
     param(
         [Parameter(Position=0,
             ValueFromPipeline=$true,
@@ -423,7 +426,7 @@ function Capture-LLDPPacket {
 #endregion
 
 #region function Parse-LLDPPacket
-function Parse-LLDPPacket {
+function ConvertFrom-LLDPPacket {
 
 <#
 
@@ -483,6 +486,7 @@ function Parse-LLDPPacket {
 #>
 
     [CmdletBinding()]
+    [Alias('Parse-LLDPPacket')]
     param(
         [Parameter(Position=0,
             Mandatory=$true,


### PR DESCRIPTION
This is a PR to fix the warning about unapproved verbs when importing the module.
Fixes #2 

I have renamed the `Capture-*` to `Get-*` and renamed the `Parse-*` to `ConvertFrom-*`. I have then added the old names as aliases and added the aliases to the module manifest for backwards compatibility.

I didn't change any of the internal references or comment-based help as I assume you prefer the original names but if you want me to do that then just let me know and I'll happily add it on as part of this PR.