### PR TITLE
Don't require CimSession / PSSession on local computer

### DIFF
--- a/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
+++ b/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
@@ -188,7 +188,7 @@ function Invoke-DiscoveryProtocolCapture {
 
                 try {
                     $CimSession = @{
-                            CimSession = New-CimSession -ComputerName $Computer -ErrorAction Stop
+                        CimSession = New-CimSession -ComputerName $Computer -ErrorAction Stop
                     }
                 } catch {
                     Write-Warning "Unable to create CimSession. Please make sure WinRM and PSRemoting is enabled on $Computer."
@@ -197,7 +197,6 @@ function Invoke-DiscoveryProtocolCapture {
 
                 $PSSession = @{
                     Session = New-PSSession -ComputerName $Computer
-
                 }
             }
 
@@ -252,7 +251,7 @@ function Invoke-DiscoveryProtocolCapture {
                     LinkLayerAddress = $LinkLayerAddress
                 }
 
-                Add-NetEventPacketCaptureProvider @PacketCaptureParams | Out-Null
+                Add-NetEventPacketCaptureProvider @PacketCaptureParams @CimSession | Out-Null
                 Add-NetEventNetworkAdapter -Name $Adapter.Name -PromiscuousMode $True @CimSession | Out-Null
 
                 Start-NetEventSession -Name $SessionName @CimSession

--- a/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
+++ b/PSDiscoveryProtocol/PSDiscoveryProtocol.psm1
@@ -1,15 +1,17 @@
 #region classes
-class DiscoveryProtocolPacket {
+class DiscoveryProtocolPacket
+{
     [string]$MachineName
     [datetime]$TimeCreated
     [int]$FragmentSize
     [byte[]]$Fragment
 
-    DiscoveryProtocolPacket([string]$MachineName, [datetime]$TimeCreated, [int]$FragmentSize, [byte[]]$Fragment) {
-        $this.MachineName = $MachineName
-        $this.TimeCreated = $TimeCreated
+    DiscoveryProtocolPacket([string]$MachineName, [datetime]$TimeCreated, [int]$FragmentSize, [byte[]]$Fragment)
+    {
+        $this.MachineName  = $MachineName
+        $this.TimeCreated  = $TimeCreated
         $this.FragmentSize = $FragmentSize
-        $this.Fragment = $Fragment
+        $this.Fragment     = $Fragment
 
         Add-Member -InputObject $this -MemberType ScriptProperty -Name IsDiscoveryProtocolPacket -Value {
             if (
@@ -40,7 +42,7 @@ class DiscoveryProtocolPacket {
 #region function Invoke-DiscoveryProtocolCapture
 function Invoke-DiscoveryProtocolCapture {
 
-    <#
+<#
 
 .SYNOPSIS
 
@@ -136,16 +138,16 @@ function Invoke-DiscoveryProtocolCapture {
     [OutputType('DiscoveryProtocolPacket')]
     [Alias('Capture-CDPPacket', 'Capture-LLDPPacket')]
     param(
-        [Parameter(Position = 0,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Position=0,
+            ValueFromPipeline=$true,
+            ValueFromPipelineByPropertyName=$true)]
         [Alias('CN', 'Computer')]
         [String[]]$ComputerName = $env:COMPUTERNAME,
 
-        [Parameter(Position = 1)]
+        [Parameter(Position=1)]
         [Int16]$Duration = $(if ($Type -eq 'LLDP') { 32 } else { 62 }),
 
-        [Parameter(Position = 2)]
+        [Parameter(Position=2)]
         [ValidateSet('CDP', 'LLDP')]
         [String]$Type,
 
@@ -186,10 +188,9 @@ function Invoke-DiscoveryProtocolCapture {
 
                 try {
                     $CimSession = @{
-                        CimSession = New-CimSession -ComputerName $Computer -ErrorAction Stop
-                    }                    
-                }
-                catch {
+                            CimSession = New-CimSession -ComputerName $Computer -ErrorAction Stop
+                    }
+                } catch {
                     Write-Warning "Unable to create CimSession. Please make sure WinRM and PSRemoting is enabled on $Computer."
                     continue
                 }
@@ -199,7 +200,7 @@ function Invoke-DiscoveryProtocolCapture {
 
                 }
             }
-    
+
             $ETLFilePath = Invoke-Command @PSSession -ScriptBlock {
                 $TempFile = New-TemporaryFile
                 $ETLFile = Rename-Item -Path $TempFile.FullName -NewName $TempFile.FullName.Replace('.tmp', '.etl') -PassThru
@@ -209,8 +210,8 @@ function Invoke-DiscoveryProtocolCapture {
             Write-Verbose "ETL File Path: $ETLFilePath"
 
             $Adapter = Get-NetAdapter -Physical @CimSession |
-            Where-Object { $_.Status -eq 'Up' -and $_.InterfaceType -eq 6 } |
-            Select-Object -First 1 Name, MacAddress
+                Where-Object {$_.Status -eq 'Up' -and $_.InterfaceType -eq 6} |
+                Select-Object -First 1 Name, MacAddress
 
             $MACAddress = [PhysicalAddress]::Parse($Adapter.MacAddress).ToString()
 
@@ -227,22 +228,20 @@ function Invoke-DiscoveryProtocolCapture {
                 }
 
                 try {
-                    New-NetEventSession -Name $SessionName -LocalFilePath $ETLFilePath -CaptureMode SaveToFile @CimSession -ErrorAction Stop | Out-Null                    
-                }
-                catch [Microsoft.Management.Infrastructure.CimException] {
+                    New-NetEventSession -Name $SessionName -LocalFilePath $ETLFilePath -CaptureMode SaveToFile @CimSession -ErrorAction Stop | Out-Null
+                } catch [Microsoft.Management.Infrastructure.CimException] {
                     if ($_.Exception.NativeErrorCode -eq 'AlreadyExists') {
                         $Message = "Another NetEventSession already exists. Run Invoke-DiscoveryProtocolCapture with -Force switch to remove existing NetEventSessions."
                         Write-Error -Message $Message
                         return
-                    }
-                    else {
+                    } else {
                         Write-Error -Exception $_
                     }
                 }
 
                 $LinkLayerAddress = switch ($Type) {
-                    'CDP' { '01-00-0c-cc-cc-cc' }
-                    'LLDP' { '01-80-c2-00-00-0e', '01-80-c2-00-00-03', '01-80-c2-00-00-00' }
+                    'CDP'   { '01-00-0c-cc-cc-cc' }
+                    'LLDP'  { '01-80-c2-00-00-0e', '01-80-c2-00-00-03', '01-80-c2-00-00-00' }
                     Default { '01-00-0c-cc-cc-cc', '01-80-c2-00-00-0e', '01-80-c2-00-00-03', '01-80-c2-00-00-00' }
                 }
 
@@ -253,7 +252,7 @@ function Invoke-DiscoveryProtocolCapture {
                     LinkLayerAddress = $LinkLayerAddress
                 }
 
-                Add-NetEventPacketCaptureProvider @PacketCaptureParams @CimSession | Out-Null
+                Add-NetEventPacketCaptureProvider @PacketCaptureParams | Out-Null
                 Add-NetEventNetworkAdapter -Name $Adapter.Name -PromiscuousMode $True @CimSession | Out-Null
 
                 Start-NetEventSession -Name $SessionName @CimSession
@@ -276,8 +275,7 @@ function Invoke-DiscoveryProtocolCapture {
 
                     try {
                         $Events = Get-WinEvent -Path $ETLFilePath -Oldest -FilterXPath "*[System[EventID=1001]]" -ErrorAction Stop
-                    }
-                    catch {
+                    } catch {
                         if ($_.FullyQualifiedErrorId -notmatch 'NoMatchingEventsFound') {
                             Write-Error -Exception $_
                         }
@@ -330,16 +328,14 @@ function Invoke-DiscoveryProtocolCapture {
                 if ($env:COMPUTERNAME -ne $Computer) {
                     Remove-PSSession @PSSession
                 }
-                
+
                 if ($FoundPacket) {
                     $FoundPacket
-                }
-                else {
+                } else {
                     Write-Warning "No discovery protocol packets captured on $Computer in $Seconds seconds."
                     return
                 }
-            }
-            else {
+            } else {
                 Write-Warning "Unable to find a connected wired adapter on $Computer."
                 return
             }
@@ -353,7 +349,7 @@ function Invoke-DiscoveryProtocolCapture {
 #region function Get-DiscoveryProtocolData
 function Get-DiscoveryProtocolData {
 
-    <#
+<#
 
 .SYNOPSIS
 
@@ -420,10 +416,10 @@ function Get-DiscoveryProtocolData {
     [CmdletBinding()]
     [Alias('Parse-CDPPacket', 'Parse-LLDPPacket')]
     param(
-        [Parameter(Position = 0,
-            Mandatory = $true,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Position=0,
+            Mandatory=$true,
+            ValueFromPipeline=$true,
+            ValueFromPipelineByPropertyName=$true)]
         [DiscoveryProtocolPacket[]]
         $Packet
     )
@@ -438,8 +434,8 @@ function Get-DiscoveryProtocolData {
     process {
         foreach ($item in $Packet) {
             switch ($item.DiscoveryProtocolType) {
-                'CDP' { $PacketData = ConvertFrom-CDPPacket -Packet $item.Fragment }
-                'LLDP' { $PacketData = ConvertFrom-LLDPPacket -Packet $item.Fragment }
+                'CDP'   { $PacketData = ConvertFrom-CDPPacket -Packet $item.Fragment }
+                'LLDP'  { $PacketData = ConvertFrom-LLDPPacket -Packet $item.Fragment }
                 Default { throw 'No valid CDP or LLDP found in $Packet' }
             }
 
@@ -456,7 +452,7 @@ function Get-DiscoveryProtocolData {
 #region function ConvertFrom-CDPPacket
 function ConvertFrom-CDPPacket {
 
-    <#
+<#
 
 .SYNOPSIS
 
@@ -491,12 +487,12 @@ function ConvertFrom-CDPPacket {
 
     [CmdletBinding()]
     param(
-        [Parameter(Position = 0,
-            Mandatory = $true)]
+        [Parameter(Position=0,
+            Mandatory=$true)]
         [byte[]]$Packet
     )
 
-    $Stream = New-Object System.IO.MemoryStream (, $Packet)
+    $Stream = New-Object System.IO.MemoryStream (,$Packet)
     $Reader = New-Object System.IO.BinaryReader $Stream
 
     $Destination = [PhysicalAddress]$Reader.ReadBytes(6)
@@ -542,12 +538,12 @@ function ConvertFrom-CDPPacket {
         $TlvLength = [System.BitConverter]::ToUInt16($Reader.ReadBytes(2)[1..0], 0)
 
         switch ($TlvType) {
-            { $_ -in $TypeString } {
+            {$_ -in $TypeString} {
                 $String = $Reader.ReadChars($TlvLength - 4) -join ''
                 $Properties.Add($Tlv.Item([int]$TlvType), $String)
             }
 
-            { $_ -in $TypeAddress } {
+            {$_ -in $TypeAddress} {
                 $NumberOfAddresses = [System.BitConverter]::ToUInt32($Reader.ReadBytes(4)[3..0], 0)
                 $Addresses = New-Object System.Collections.Generic.List[String]
 
@@ -557,8 +553,7 @@ function ConvertFrom-CDPPacket {
 
                     if ($ProtocolLength -eq 1) {
                         $Protocol = $Reader.ReadByte()
-                    }
-                    else {
+                    } else {
                         $Protocol = [System.BitConverter]::ToInt64($Reader.ReadBytes(8)[7..0], 0)
                     }
 
@@ -568,8 +563,7 @@ function ConvertFrom-CDPPacket {
                     if (($ProtocolType -eq 0x01 -and $Protocol -eq $IPv4) -or ($ProtocolType -eq 0x02 -and $Protocol -eq $IPv6)) {
                         $IPAddress = [System.Net.IPAddress]::new($AddressBytes).IPAddressToString
                         $Addresses.Add($IPAddress)
-                    }
-                    else {
+                    } else {
                         $ProtocolBytes = [System.BitConverter]::GetBytes($Protocol)[7..0]
                         $ProtocolHex = [System.BitConverter]::ToString($ProtocolBytes)
                         $AddressHex = [System.BitConverter]::ToString($AddressBytes)
@@ -617,7 +611,7 @@ function ConvertFrom-CDPPacket {
 #region function ConvertFrom-LLDPPacket
 function ConvertFrom-LLDPPacket {
 
-    <#
+<#
 
 .SYNOPSIS
 
@@ -650,8 +644,8 @@ function ConvertFrom-LLDPPacket {
 
     [CmdletBinding()]
     param(
-        [Parameter(Position = 0,
-            Mandatory = $true)]
+        [Parameter(Position=0,
+            Mandatory=$true)]
         [byte[]]$Packet
     )
 
@@ -672,8 +666,8 @@ function ConvertFrom-LLDPPacket {
     process {
 
         $Destination = [PhysicalAddress]::new($Packet[0..5])
-        $Source = [PhysicalAddress]::new($Packet[6..11])
-        $EtherType = [BitConverter]::ToString($Packet[12..13])
+        $Source      = [PhysicalAddress]::new($Packet[6..11])
+        $EtherType   = [BitConverter]::ToString($Packet[12..13])
 
         Write-Verbose "Destination    : $Destination"
         Write-Verbose "Source         : $Source"
@@ -684,12 +678,14 @@ function ConvertFrom-LLDPPacket {
         $Mask = 0x01FF
         $Hash = @{}
 
-        while ($Offset -lt $Packet.Length) {
+        while ($Offset -lt $Packet.Length)
+        {
             $Type = $Packet[$Offset] -shr 1
             $Length = [BitConverter]::ToUInt16($Packet[($Offset + 1)..$Offset], 0) -band $Mask
             $Offset += 2
 
-            switch ($Type) {
+            switch ($Type)
+            {
                 $TlvType.ChassisId {
                     $Subtype = $Packet[($Offset)]
 
@@ -701,8 +697,7 @@ function ConvertFrom-LLDPPacket {
                         $AddressFamily = $Packet[($Offset + 1)]
                         if ($AddressFamily -in 1, 2) {
                             $Hash.Add('ChassisId', [IPAddress]::new($Packet[($Offset + 2)..($Offset + $Length - 1)]))
-                        }
-                        else {
+                        } else {
                             $Bytes = $Packet[($Offset + 2)..($Offset + $Length - 1)]
                             $Hex = [System.BitConverter]::ToString($Bytes)
                             $Ascii = [System.Text.Encoding]::ASCII.GetString($Bytes)
@@ -736,8 +731,7 @@ function ConvertFrom-LLDPPacket {
                         $AddressFamily = $Packet[($Offset + 1)]
                         if ($AddressFamily -in 1, 2) {
                             $Hash.Add('Port', [IPAddress]::new($Packet[($Offset + 2)..($Offset + $Length - 1)]))
-                        }
-                        else {
+                        } else {
                             $Bytes = $Packet[($Offset + 2)..($Offset + $Length - 1)]
                             $Hex = [System.BitConverter]::ToString($Bytes)
                             $Ascii = [System.Text.Encoding]::ASCII.GetString($Bytes)
@@ -795,8 +789,7 @@ function ConvertFrom-LLDPPacket {
 
                     if ($Subtype -in 1, 2) {
                         $Addresses.Add(([System.Net.IPAddress][byte[]]$Packet[($Offset + 2)..($Offset + $AddrLen)]).IPAddressToString)
-                    }
-                    else {
+                    } else {
                         $Bytes = $Packet[($Offset + 2)..($Offset + $AddrLen)]
                         $Hex = [System.BitConverter]::ToString($Bytes)
                         $Ascii = [System.Text.Encoding]::ASCII.GetString($Bytes)
@@ -875,7 +868,7 @@ function ConvertFrom-LLDPPacket {
 #region function Export-Pcap
 function Export-Pcap {
 
-    <#
+<#
 
 .SYNOPSIS
 
@@ -915,39 +908,38 @@ function Export-Pcap {
 
     [CmdletBinding(DefaultParameterSetName = 'DiscoveryProtocolPacket')]
     param(
-        [Parameter(Mandatory = $true,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
-            ParameterSetName = 'DiscoveryProtocolPacket')]
+        [Parameter(Mandatory=$true,
+            ValueFromPipeline=$true,
+            ValueFromPipelineByPropertyName=$true,
+            ParameterSetName='DiscoveryProtocolPacket')]
         [DiscoveryProtocolPacket[]]$Packet,
 
-        [Parameter(Mandatory = $true,
-            ParameterSetName = 'BytesAndDateTime')]
+        [Parameter(Mandatory=$true,
+            ParameterSetName='BytesAndDateTime')]
         [byte[]]$Bytes,
 
-        [Parameter(Mandatory = $false,
-            ParameterSetName = 'BytesAndDateTime')]
+        [Parameter(Mandatory=$false,
+            ParameterSetName='BytesAndDateTime')]
         [datetime]$DateTime = (Get-Date),
 
-        [Parameter(Mandatory = $true)]
-        [ValidateScript( {
-                if ([System.IO.Path]::IsPathRooted($_)) {
-                    $AbsolutePath = $_
-                }
-                else {
-                    $AbsolutePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($_)
-                }
-                if (-not(Test-Path (Split-Path $AbsolutePath -Parent))) {
-                    throw "Folder does not exist"
-                }
-                if ($_ -notmatch '\.pcap$') {
-                    throw "Extension must be pcap"
-                }
-                return $true
-            })]
+        [Parameter(Mandatory=$true)]
+        [ValidateScript({
+            if ([System.IO.Path]::IsPathRooted($_)) {
+                $AbsolutePath = $_
+            } else {
+                $AbsolutePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($_)
+            }
+            if (-not(Test-Path (Split-Path $AbsolutePath -Parent))) {
+                throw "Folder does not exist"
+            }
+            if ($_ -notmatch '\.pcap$') {
+                throw "Extension must be pcap"
+            }
+            return $true
+        })]
         [System.IO.FileInfo]$Path,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [switch]$Invoke
     )
 


### PR DESCRIPTION
Hi @lahell,

if `$env:Computer -eq $Computer` we don't need a CimSession or PSSession to execute the commands. By using [PowerShell Splatting](https://docs.microsoft.com/en-US/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.1) we can optionally pass the sessions to the cmdlets.

If you merge this PR: 

1. The user doesn't need to enable WinRM/PSRemoting on the local system
2. I can stay closer to the upstream branch by writing a wrapper for my NETworkManager

```
Import-Module $PSScriptRoot\PSDiscoveryProtocol\PSDiscoveryProtocol.psm1

Invoke-DiscoveryProtocolCapture -Type LLDP -Duration 10 -Verbose -Force | Get-DiscoveryProtocolData

Remove-Module PSDiscoveryProtocol
``` 

Tests (but please try it by yourself first 😄 ):
![image](https://user-images.githubusercontent.com/16019165/116760833-53640b80-aa16-11eb-93ec-bdc2cdcbda5f.png)

I also formatted the code with vscode and the powershell plugin :sweat_smile: . 

Please review and give me some feedback

Greetings
BornToBeRoot

Edit: This shouldn't break any existing scripts... 